### PR TITLE
给进程添加别名。

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "env": { "es6": true, "node": true },
+  "globals": { "argv": true },
+  "extends": "elemefe"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.swp
+*.log
+!.eslintrc
+node_modules

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,16 +9,6 @@ let connection = new Connection(socket);
 
 const _init = connection.call('__init', { pid: process.pid });
 
-let isAlias = false;
-
-class AlreadyAliasError extends Error {
-  constructor() {
-    super('socket ipc already alias error');
-    this.name = 'SOCKET_IPC_ALREADY_ALIAS_ERROR';
-    this.status = 400;
-  }
-}
-
 class IPC {
 
   static call(...args) { return connection.call(...args); }
@@ -74,17 +64,9 @@ class IPC {
   static callAlias(alias, ...args) { return connection.call('__callAlias', { alias, args }); }
 
   static setAlias(alias, ...args) {
-    if (isAlias) {
-      throw new AlreadyAliasError();
-    }
-
-    isAlias = true;
     if (master) {
       return master.__setAlias(null, {alias, pid: process.pid})
     } else {
-      cluster.worker.process.on('exit', () => {
-        return connection.call('__deleteAlias', { alias, pid: process.pid });
-      });
       return connection.call('__setAlias', { alias, pid: process.pid });
     }
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,11 +2,22 @@ const net = require('net');
 const master = require('./master');
 const Connection = require('./connection');
 const address = JSON.parse(process.env.SOCKETIPC_ADDRESS);
+const cluster = require('cluster');
 
 let socket = net.connect(address);
 let connection = new Connection(socket);
 
-connection.call('__init', { pid: process.pid });
+const _init = connection.call('__init', { pid: process.pid });
+
+let isAlias = false;
+
+class AlreadyAliasError extends Error {
+  constructor() {
+    super('socket ipc already alias error');
+    this.name = 'SOCKET_IPC_ALREADY_ALIAS_ERROR';
+    this.status = 400;
+  }
+}
 
 class IPC {
 
@@ -55,6 +66,28 @@ class IPC {
   }
 
   static callWorker(pid, ...args) { return connection.call('__callWorker', { pid, args }); }
+
+  static ready() {
+    return _init;
+  }
+
+  static callAlias(alias, ...args) { return connection.call('__callAlias', { alias, args }); }
+
+  static setAlias(alias, ...args) {
+    if (isAlias) {
+      throw new AlreadyAliasError();
+    }
+
+    isAlias = true;
+    if (master) {
+      return master.__setAlias(null, {alias, pid: process.pid})
+    } else {
+      cluster.worker.process.on('exit', () => {
+        return connection.call('__deleteAlias', { alias, pid: process.pid });
+      });
+      return connection.call('__setAlias', { alias, pid: process.pid });
+    }
+  }
 
 };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,7 +2,6 @@ const net = require('net');
 const master = require('./master');
 const Connection = require('./connection');
 const address = JSON.parse(process.env.SOCKETIPC_ADDRESS);
-const cluster = require('cluster');
 
 let socket = net.connect(address);
 let connection = new Connection(socket);

--- a/lib/main.js
+++ b/lib/main.js
@@ -62,9 +62,9 @@ class IPC {
 
   static callAlias(alias, ...args) { return connection.call('__callAlias', { alias, args }); }
 
-  static setAlias(alias, ...args) {
+  static setAlias(alias) {
     if (master) {
-      return master.__setAlias(null, {alias, pid: process.pid})
+      return master.__setAlias(null, {alias, pid: process.pid});
     } else {
       return connection.call('__setAlias', { alias, pid: process.pid });
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -70,6 +70,6 @@ class IPC {
     }
   }
 
-};
+}
 
 module.exports = IPC;

--- a/lib/master.js
+++ b/lib/master.js
@@ -33,17 +33,6 @@ if (cluster.isMaster) {
   const aliasMap = new Map();
   const aliasPids = new Set();
 
-  const filterWorkerByPid = function (pid) {
-    const workers = cluster.workers;
-    for(let i of Object.keys(workers)) {
-      const worker = workers[i];
-      if (worker.process.pid === pid) {
-        return worker;
-      }
-    }
-    throw new PidNotFoundError();
-  }
-
   const __init = buildChains(function({ pid }) {
     storage.set(pid, this);
     this.socket.on('error', () => this.socket.destroy());
@@ -77,6 +66,21 @@ if (cluster.isMaster) {
 
   const __callWorker = buildChains(callWorker);
 
+  const deleteAlias = function (alias, pid) {
+    aliasPids.delete(pid);
+    const pidGroup = aliasMap.get(alias);
+    if (!pidGroup) {
+      return false;
+    }
+
+    pidGroup.delete(pid);
+    if (pidGroup.size <= 0) {
+      aliasMap.delete(alias);
+    }
+
+    return true;
+  }
+
   const __callAlias = buildChains(function({ alias, args }) {
     const pidGroup = aliasMap.get(alias);
     if (!pidGroup) {
@@ -84,28 +88,21 @@ if (cluster.isMaster) {
     }
 
     const results = [];
+
     for(let pid of pidGroup) {
-      results.push(callWorker({pid, args}));
+      try {
+        results.push(callWorker({pid, args}));
+      } catch (error) {
+        if (!error.name === 'SOCKET_IPC_PID_NOT_FOUND') {
+          throw error
+        } else {
+          deleteAlias(alias, pid);
+        }
+      }
     }
 
     return Promise.all(results);
   });
-
-  const exitDeleteAlias = function (alias, pid) {
-    if (process.pid === pid) {
-      return Promise.resolve(true);
-    }
-
-    const worker = filterWorkerByPid(pid);
-    worker.process.once('exit', () => {
-      aliasPids.delete(pid);
-      const pidGroup = aliasMap.get(alias);
-      pidGroup.delete(pid);
-      if (pidGroup.size <= 0) {
-        aliasMap.delete(alias);
-      }
-    });
-  }
 
   const __setAlias = buildChains(function({ alias, pid }) {
     if (!storage.has(pid)) throw new PidNotFoundError();
@@ -124,7 +121,6 @@ if (cluster.isMaster) {
     pidGroup.add(pid);
 
     aliasMap.set(alias, pidGroup);
-    exitDeleteAlias(alias, pid);
     return Promise.resolve(true);
   });
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -9,8 +9,8 @@ class PidNotFoundError extends Error {
 }
 
 class AliasNotFoundError extends Error {
-  constructor() {
-    super('socket ipc alias not found');
+  constructor(message = 'socket ipc alias not found') {
+    super(message);
     this.name = 'SOCKET_IPC_ALIAS_NOT_FOUND_ERROR';
     this.status = 400;
   }
@@ -80,7 +80,7 @@ if (cluster.isMaster) {
   const __callAlias = buildChains(function({ alias, args }) {
     const pidGroup = aliasMap.get(alias);
     if (!pidGroup) {
-      throw new AliasNotFoundError();
+      throw new AliasNotFoundError(`alias: ${alias} not found`);
     }
 
     const results = [];

--- a/lib/master.js
+++ b/lib/master.js
@@ -16,6 +16,14 @@ class AliasNotFoundError extends Error {
   }
 }
 
+class AlreadyAliasError extends Error {
+  constructor(message = 'socket ipc already alias error') {
+    super(message);
+    this.name = 'SOCKET_IPC_ALREADY_ALIAS_ERROR';
+    this.status = 400;
+  }
+}
+
 if (cluster.isMaster) {
 
   const net = require('net');
@@ -23,6 +31,18 @@ if (cluster.isMaster) {
   const { buildChains } = require('./utils');
   const storage = new Map();
   const aliasMap = new Map();
+  const aliasPids = new Set();
+
+  const filterWorkerByPid = function (pid) {
+    const workers = cluster.workers;
+    for(let i of Object.keys(workers)) {
+      const worker = workers[i];
+      if (worker.process.pid === pid) {
+        return worker;
+      }
+    }
+    throw new PidNotFoundError();
+  }
 
   const __init = buildChains(function({ pid }) {
     storage.set(pid, this);
@@ -71,9 +91,30 @@ if (cluster.isMaster) {
     return Promise.all(results);
   });
 
+  const exitDeleteAlias = function (alias, pid) {
+    if (process.pid === pid) {
+      return Promise.resolve(true);
+    }
+
+    const worker = filterWorkerByPid(pid);
+    worker.process.once('exit', () => {
+      aliasPids.delete(pid);
+      const pidGroup = aliasMap.get(alias);
+      pidGroup.delete(pid);
+      if (pidGroup.size <= 0) {
+        aliasMap.delete(alias);
+      }
+    });
+  }
+
   const __setAlias = buildChains(function({ alias, pid }) {
     if (!storage.has(pid)) throw new PidNotFoundError();
 
+    if (aliasPids.has(pid)) {
+      throw new AlreadyAliasError(`${pid} already alias`);
+    }
+
+    aliasPids.add(pid);
     let pidGroup = aliasMap.get(alias);
 
     if (!pidGroup) {
@@ -83,15 +124,8 @@ if (cluster.isMaster) {
     pidGroup.add(pid);
 
     aliasMap.set(alias, pidGroup);
+    exitDeleteAlias(alias, pid);
     return Promise.resolve(true);
-  });
-
-  const __deleteAlias = buildChains(function({ alias, pid }) {
-    const pidGroup = aliasMap.get(alias);
-    if (!pidGroup) {
-      throw new AliasNotFoundError();
-    }
-    return Promise.resolve(pidGroup.delete(pid));
   });
 
   let table = {
@@ -100,7 +134,6 @@ if (cluster.isMaster) {
     __registerMaster,
     __callWorker,
     __setAlias,
-    __deleteAlias,
     __callAlias
   };
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -31,7 +31,6 @@ if (cluster.isMaster) {
   const { buildChains } = require('./utils');
   const storage = new Map();
   const aliasMap = new Map();
-  const aliasPids = new Set();
 
   const __init = buildChains(function({ pid }) {
     storage.set(pid, this);
@@ -66,39 +65,31 @@ if (cluster.isMaster) {
 
   const __callWorker = buildChains(callWorker);
 
-  const deleteAlias = function (alias, pid) {
-    aliasPids.delete(pid);
-    const pidGroup = aliasMap.get(alias);
-    if (!pidGroup) {
-      return false;
-    }
-
-    pidGroup.delete(pid);
-    if (pidGroup.size <= 0) {
-      aliasMap.delete(alias);
-    }
-
-    return true;
-  }
-
   const __callAlias = buildChains(function({ alias, args }) {
-    const pidGroup = aliasMap.get(alias);
-    if (!pidGroup) {
-      throw new AliasNotFoundError(`alias: ${alias} not found`);
-    }
-
     const results = [];
+    const notConnectPids = [];
+    for(let [pid, _alias] of aliasMap.entries()) {
+      if (_alias !== alias) {
+        continue
+      }
 
-    for(let pid of pidGroup) {
       try {
         results.push(callWorker({pid, args}));
       } catch (error) {
-        if (!error.name === 'SOCKET_IPC_PID_NOT_FOUND') {
+        if (error.name !== 'SOCKET_IPC_PID_NOT_FOUND') {
           throw error
         } else {
-          deleteAlias(alias, pid);
+          notConnectPids.push(pid);
         }
       }
+    }
+
+    if (results.length === 0) {
+      throw new AliasNotFoundError(`alias: ${alias} not found`);
+    }
+
+    for(let pid of notConnectPids) {
+      aliasMap.delete(pid)
     }
 
     return Promise.all(results);
@@ -107,20 +98,11 @@ if (cluster.isMaster) {
   const __setAlias = buildChains(function({ alias, pid }) {
     if (!storage.has(pid)) throw new PidNotFoundError();
 
-    if (aliasPids.has(pid)) {
+    if (aliasMap.has(pid)) {
       throw new AlreadyAliasError(`${pid} already alias`);
     }
 
-    aliasPids.add(pid);
-    let pidGroup = aliasMap.get(alias);
-
-    if (!pidGroup) {
-        pidGroup = new Set();
-    }
-
-    pidGroup.add(pid);
-
-    aliasMap.set(alias, pidGroup);
+    aliasMap.set(pid, alias);
     return Promise.resolve(true);
   });
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -61,35 +61,35 @@ if (cluster.isMaster) {
       if (thisPid === pid) return connection.call(...args);
     }
     throw new PidNotFoundError();
-  }
+  };
 
   const __callWorker = buildChains(callWorker);
 
   const __callAlias = buildChains(function({ alias, args }) {
     const results = [];
     const notConnectPids = [];
-    for(let [pid, _alias] of aliasMap.entries()) {
+    for (let [pid, _alias] of aliasMap.entries()) {
       if (_alias !== alias) {
-        continue
+        continue;
       }
 
       try {
         results.push(callWorker({pid, args}));
       } catch (error) {
         if (error.name !== 'SOCKET_IPC_PID_NOT_FOUND') {
-          throw error
+          throw error;
         } else {
           notConnectPids.push(pid);
         }
       }
     }
 
-    if (results.length === 0) {
-      throw new AliasNotFoundError(`alias: ${alias} not found`);
+    for (let pid of notConnectPids) {
+      aliasMap.delete(pid);
     }
 
-    for(let pid of notConnectPids) {
-      aliasMap.delete(pid)
+    if (results.length === 0) {
+      throw new AliasNotFoundError(`alias: ${alias} not found`);
     }
 
     return Promise.all(results);

--- a/lib/master.js
+++ b/lib/master.js
@@ -8,12 +8,21 @@ class PidNotFoundError extends Error {
   }
 }
 
+class AliasNotFoundError extends Error {
+  constructor() {
+    super('socket ipc alias not found');
+    this.name = 'SOCKET_IPC_ALIAS_NOT_FOUND_ERROR';
+    this.status = 400;
+  }
+}
+
 if (cluster.isMaster) {
 
   const net = require('net');
   const Connection = require('./connection');
   const { buildChains } = require('./utils');
   const storage = new Map();
+  const aliasMap = new Map();
 
   const __init = buildChains(function({ pid }) {
     storage.set(pid, this);
@@ -39,14 +48,61 @@ if (cluster.isMaster) {
     table[name] = buildChains(...[].concat(handlers));
   });
 
-  const __callWorker = buildChains(function({ pid, args }) {
+  const callWorker = function({ pid, args }) {
     for (let [ thisPid, connection ] of storage) {
       if (thisPid === pid) return connection.call(...args);
     }
     throw new PidNotFoundError();
+  }
+
+  const __callWorker = buildChains(callWorker);
+
+  const __callAlias = buildChains(function({ alias, args }) {
+    const pidGroup = aliasMap.get(alias);
+    if (!pidGroup) {
+      throw new AliasNotFoundError();
+    }
+
+    const results = [];
+    for(let pid of pidGroup) {
+      results.push(callWorker({pid, args}));
+    }
+
+    return Promise.all(results);
   });
 
-  let table = { __init, __broadcast, __registerMaster, __callWorker };
+  const __setAlias = buildChains(function({ alias, pid }) {
+    if (!storage.has(pid)) throw new PidNotFoundError();
+
+    let pidGroup = aliasMap.get(alias);
+
+    if (!pidGroup) {
+        pidGroup = new Set();
+    }
+
+    pidGroup.add(pid);
+
+    aliasMap.set(alias, pidGroup);
+    return Promise.resolve(true);
+  });
+
+  const __deleteAlias = buildChains(function({ alias, pid }) {
+    const pidGroup = aliasMap.get(alias);
+    if (!pidGroup) {
+      throw new AliasNotFoundError();
+    }
+    return Promise.resolve(pidGroup.delete(pid));
+  });
+
+  let table = {
+    __init,
+    __broadcast,
+    __registerMaster,
+    __callWorker,
+    __setAlias,
+    __deleteAlias,
+    __callAlias
+  };
 
   let server = net.createServer(socket => {
     void new Connection(socket, table);

--- a/tests/call-alias.js
+++ b/tests/call-alias.js
@@ -8,6 +8,12 @@ const workerAlias = 'worker'
 let COUNT = 3;
 
 if (cluster.isMaster) {
+  try {
+    setAlias('test')
+  } catch (e) {
+    assert(e.name, 'SOCKET_IPC_PID_NOT_FOUND')
+  }
+
   ready().then(() => {
     setAlias('master').then(result => assert.equal(result, true));
 

--- a/tests/call-alias.js
+++ b/tests/call-alias.js
@@ -1,43 +1,41 @@
 const cluster = require('cluster');
 const assert = require('assert');
 const SequenceTester = require('sequence-tester');
-const { call, register, registerMaster, broadcast, callWorker } = require('..');
-const { setAlias, callAlias, ready } = require('..');
+const { call, register, registerMaster, setAlias, callAlias, ready } = require('..');
 
-const workerAlias = 'worker'
+const workerAlias = 'worker';
 let COUNT = 3;
 
 if (cluster.isMaster) {
   try {
-    setAlias('test')
+    setAlias('test');
   } catch (e) {
-    assert(e.name, 'SOCKET_IPC_PID_NOT_FOUND')
+    assert(e.name, 'SOCKET_IPC_PID_NOT_FOUND');
   }
 
   callAlias(workerAlias, 'ok').catch(err => {
-    assert(err.name, 'SOCKET_IPC_ALIAS_NOT_FOUND_ERROR')
-  })
+    assert(err.name, 'SOCKET_IPC_ALIAS_NOT_FOUND_ERROR');
+  });
 
   ready().then(() => {
     setAlias('master').then(result => assert.equal(result, true));
 
     try {
-      setAlias('error')
+      setAlias('error');
     } catch (e) {
-      assert(e.name, 'SOCKET_IPC_ALREADY_ALIAS_ERROR')
+      assert(e.name, 'SOCKET_IPC_ALREADY_ALIAS_ERROR');
     }
 
     let stInit = new SequenceTester(Array.from({ length: COUNT }, () => true));
 
     registerMaster('init', () => stInit.assert(true));
 
-
     stInit.then(() => {
       return callAlias(workerAlias, 'ok');
     }).then((result) => {
       assert.deepEqual(result, Array.from({ length: COUNT }, () => 'ok'));
     }).then(() => {
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve) => {
         workers[0].kill();
         workers[0].on('exit', () => {
           resolve();
@@ -56,15 +54,13 @@ if (cluster.isMaster) {
   }
 } else {
   register('ok', () => {
-    return Promise.resolve('ok')
+    return Promise.resolve('ok');
   });
-
-  let st2 = new SequenceTester(Array.from({ length: COUNT }, () => true));
 
   ready().then(() => {
     setAlias('worker').then(results => {
       call('init');
       assert.equal(results, true);
     });
-  })
+  });
 }

--- a/tests/call-alias.js
+++ b/tests/call-alias.js
@@ -14,6 +14,10 @@ if (cluster.isMaster) {
     assert(e.name, 'SOCKET_IPC_PID_NOT_FOUND')
   }
 
+  callAlias(workerAlias, 'ok').catch(err => {
+    assert(err.name, 'SOCKET_IPC_ALIAS_NOT_FOUND_ERROR')
+  })
+
   ready().then(() => {
     setAlias('master').then(result => assert.equal(result, true));
 

--- a/tests/call-alias.js
+++ b/tests/call-alias.js
@@ -1,0 +1,60 @@
+const cluster = require('cluster');
+const assert = require('assert');
+const SequenceTester = require('sequence-tester');
+const { call, register, registerMaster, broadcast, callWorker } = require('..');
+const { setAlias, callAlias, ready } = require('..');
+
+const workerAlias = 'worker'
+let COUNT = 3;
+
+if (cluster.isMaster) {
+  ready().then(() => {
+    setAlias('master').then(result => assert.equal(result, true));
+
+    try {
+      setAlias('error')
+    } catch (e) {
+      assert(e.name, 'SOCKET_IPC_ALREADY_ALIAS_ERROR')
+    }
+
+    let stInit = new SequenceTester(Array.from({ length: COUNT }, () => true));
+
+    registerMaster('init', () => stInit.assert(true));
+
+
+    stInit.then(() => {
+      return callAlias(workerAlias, 'ok');
+    }).then((result) => {
+      assert.deepEqual(result, Array.from({ length: COUNT }, () => 'ok'));
+    }).then(() => {
+      return new Promise((resolve, reject) => {
+        workers[0].kill();
+        workers[0].on('exit', () => {
+          resolve();
+        });
+      });
+    }).then(() => {
+      return callAlias(workerAlias, 'ok');
+    }).then((result) => {
+      return assert.deepEqual(result, Array.from({ length: COUNT - 1 }, () => 'ok'));
+    }).then(() => process.exit(), console.error);
+
+  });
+  const workers = [];
+  for (let i = 0; i < COUNT; i++) {
+    workers.push(cluster.fork());
+  }
+} else {
+  register('ok', () => {
+    return Promise.resolve('ok')
+  });
+
+  let st2 = new SequenceTester(Array.from({ length: COUNT }, () => true));
+
+  ready().then(() => {
+    setAlias('worker').then(results => {
+      call('init');
+      assert.equal(results, true);
+    });
+  })
+}


### PR DESCRIPTION
规则：
1.一个进程只能注册一次别名。
2.不同进程能使用同一个别名。


别名调用是通过 callWorker 来调用，所以得等到 init 以后才能注册别名。

使用别名调用的时候，得确定别名是否已经注册。